### PR TITLE
Handling adapter errors

### DIFF
--- a/src/pages/LatestBlocks.jsx
+++ b/src/pages/LatestBlocks.jsx
@@ -14,7 +14,7 @@ export function LatestBlocks() {
         if (aliceNetAdapter && !aliceNetAdapter.blocksStarted) {
             aliceNetAdapter.startMonitoringBlocks();
         }
-        return () => { if (aliceNetAdapter && aliceNetAdapter) { aliceNetAdapter.blocksReset() } }
+        //return () => { if (aliceNetAdapter && aliceNetAdapter) { aliceNetAdapter.blocksReset() } }
     }, [aliceNetAdapter]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const rows = aliceNetAdapter.blocks?.slice(0, aliceNetAdapter.blocksMaxLen).map((e, i) => {

--- a/src/pages/LatestTransactions.jsx
+++ b/src/pages/LatestTransactions.jsx
@@ -8,18 +8,8 @@ const HEADERS_TX = ["Value", "TX Index", "Owner"]
 
 export function LatestTransactions() {
     useSelector(s => s.aliceNetAdapter); // Listen to aliceNetAdapter State
-
-    // Start monitor when component mounts
-    // useEffect(() => {
-    //     if (aliceNetAdapter && !aliceNetAdapter.blocksStarted) {
-    //         aliceNetAdapter.monitorBlocks();  //TODO monitor txs
-    //     }
-    //     return () => { if (aliceNetAdapter) { aliceNetAdapter.blocksReset() } }
-    // }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
     //TODO monitor txs
     const rows = aliceNetAdapter.blocks?.slice(0, aliceNetAdapter.blocksMaxLen).map((e, i) => {
-        //TODO monitor txs
         return {
             [HEADERS_TX[0]]: e['BClaims']['Height'],
             [HEADERS_TX[1]]: e['BClaims']['TxCount'] ? e['BClaims']['TxCount'] : 0,
@@ -28,8 +18,8 @@ export function LatestTransactions() {
     })
 
     return <CustomTable
-        Icon={() => <TxIcon />}
-        headers={HEADERS_TX}
-        rows={rows}
-        title={"Latest Transactions"} />
+            Icon={() => <TxIcon />}
+            headers={HEADERS_TX}
+            rows={rows}
+            title={"Latest Transactions"} />
 }

--- a/src/pages/blockExplorer/BlockExplorer.jsx
+++ b/src/pages/blockExplorer/BlockExplorer.jsx
@@ -19,8 +19,14 @@ export function BlockExplorer(props) {
             const height = params && params.height;
             
             if (height) {
-                const block = await aliceNetAdapter.getBlock(height);
-                setBlockInfo(block);
+                try {
+                    aliceNetAdapter.clearError();
+                    const block = await aliceNetAdapter.getBlock(height);
+                    setBlockInfo(block);
+                }catch(error){
+                    aliceNetAdapter.error = error.message;
+                    aliceNetAdapter.busy = false;
+                }
             }
 
             setLoadingStatus(false);

--- a/src/pages/dataExplorer/DataExplorer.jsx
+++ b/src/pages/dataExplorer/DataExplorer.jsx
@@ -17,8 +17,14 @@ export function DataExplorer(props) {
             const address = params && params.address;
 
             if (address) {
-                const [dataStores] = await aliceNetAdapter.getDataStoresForAddres(address);
-                setDsView(dataStores);
+                try {
+                    aliceNetAdapter.clearError();
+                    const [dataStores] = await aliceNetAdapter.getDataStoresForAddres(address);
+                    setDsView(dataStores);
+                } catch(error){
+                    aliceNetAdapter.error = error.message;
+                    aliceNetAdapter.busy = false;
+                }
             }
 
             setLoadingStatus(false);

--- a/src/pages/txExplorer/TxExplorer.jsx
+++ b/src/pages/txExplorer/TxExplorer.jsx
@@ -20,10 +20,17 @@ export function TxExplorer(props) {
         const getTx = async () => {
             const hash = params && params.hash;
             if (hash) {
-                setTxHash(hash);
-                const tx = await aliceNetAdapter.viewTransaction(hash);
-                setTxInfo(tx);
+                try {
+                    aliceNetAdapter.clearError();
+                    setTxHash(hash);
+                    const tx = await aliceNetAdapter.viewTransaction(hash);
+                    setTxInfo(tx);
+                } catch(error){
+                    aliceNetAdapter.error = error.message;
+                    aliceNetAdapter.busy = false;
+                }
             }
+            
 
             setLoadingStatus(false);
         }


### PR DESCRIPTION
Remove blocksReset() call (non existant function)
Handle adapter errors (Cannot access 'errMsg' before initialization)