### PR TITLE
Component Refactoring: "two columns row"

### DIFF
--- a/src/components/blockList/BlockList.jsx
+++ b/src/components/blockList/BlockList.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Button, Grid, Icon } from "semantic-ui-react"
-import { content, CopyTooltip } from "components";
+import { content, CopyTooltip, TwoColumnsRow } from "components";
 import { useHistory } from "react-router-dom";
 import { aliceNetAdapter } from "adapter/alicenetadapter";
-import { TwoColumnsRow } from "./TwoColumnsRow";
 
 export function BlockList({ blockInfo }) {
 
@@ -63,7 +62,6 @@ export function BlockList({ blockInfo }) {
                 <p>{txCount ? txCount : 0}</p>
             </TwoColumnsRow>
 
-
             <TwoColumnsRow title="Previous Block" tooltipContent={content.previousBlock}>
                 <CopyTooltip value={prevBlock} content="Copy Hash">
                     <p className="break-all">{`0x${prevBlock}`}</p>
@@ -75,7 +73,6 @@ export function BlockList({ blockInfo }) {
                     <p className="break-all">{`0x${txRoot}`}</p>
                 </CopyTooltip>
             </TwoColumnsRow>
-
 
             <TwoColumnsRow title="State Root" tooltipContent={content.stateRoot}>
                 <CopyTooltip value={stateRoot} content="Copy Hash">

--- a/src/components/datastoreView/DatastoreView.jsx
+++ b/src/components/datastoreView/DatastoreView.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Grid } from "semantic-ui-react";
-import { CollapsableCard, content, CopyTooltip, HelpTooltip } from "components";
+import { CollapsableCard, content, CopyTooltip, TwoColumnsRow } from "components";
 import { aliceNetAdapter } from "adapter/alicenetadapter";
 import { Link } from "react-router-dom";
 
@@ -20,101 +20,53 @@ export function DatastoreView({ datastoreInfo }) {
 
                     <Grid padded="vertically" className="mx-0 break-words" columns={"equal"} stackable>
 
-                        <Grid.Row
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2"
-                            columns={2}
-                        >
+                        <TwoColumnsRow title="Index" tooltipContent={content.index}>
+                            <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['Index']} content="Copy Index">
+                                <p className="break-all">{dataStore['DSLinker']['DSPreImage']['Index']}</p>
+                            </CopyTooltip>
+                        </TwoColumnsRow>
 
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.index} />
-                                <p>Index</p>
-                            </Grid.Column>
+                        <TwoColumnsRow title="Data" tooltipContent={content.rawData}>
+                            <CopyTooltip
+                                value={dataStore['DSLinker']['DSPreImage']['RawData']}
+                                content="Copy Value"
+                            >
+                                <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['RawData']}`}</p>
+                            </CopyTooltip>
+                        </TwoColumnsRow>
 
-                            <Grid.Column className="p-0">
-                                <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['Index']} content="Copy Index">
-                                    <p className="break-all">{dataStore['DSLinker']['DSPreImage']['Index']}</p>
-                                </CopyTooltip>
-                            </Grid.Column>
+                        <TwoColumnsRow title="Expires" tooltipContent={content.expires}>
+                            <CopyTooltip
+                                value={aliceNetAdapter.getDSExp(
+                                    dataStore['DSLinker']['DSPreImage']['RawData'],
+                                    dataStore['DSLinker']['DSPreImage']['Deposit'],
+                                    dataStore['DSLinker']['DSPreImage']['IssuedAt']
+                                )}
+                                content="Copy Value"
+                            >
+                                <p>{aliceNetAdapter.getDSExp(
+                                    dataStore['DSLinker']['DSPreImage']['RawData'],
+                                    dataStore['DSLinker']['DSPreImage']['Deposit'],
+                                    dataStore['DSLinker']['DSPreImage']['IssuedAt']
+                                )}</p>
+                            </CopyTooltip>
+                        </TwoColumnsRow>
 
-                        </Grid.Row>
-
-                        <Grid.Row
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2"
-                            columns={2}
-                        >
-
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.rawData} />
-                                <p>Data</p>
-                            </Grid.Column>
-
-                            <Grid.Column className="p-0">
-                                <CopyTooltip
-                                    value={dataStore['DSLinker']['DSPreImage']['RawData']}
-                                    content="Copy Value"
+                        <TwoColumnsRow title="Transaction Hash" tooltipContent={content.txHash}>
+                            <CopyTooltip value={dataStore['DSLinker']['TxHash']} content="Copy Hash">
+                                <Link
+                                    className="text-neongreen hover:text-neongreen hover:opacity-80 break-all"
+                                    to={`/tx/${dataStore['DSLinker']['TxHash']}`}
                                 >
-                                    <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['RawData']}`}</p>
-                                </CopyTooltip>
-                            </Grid.Column>
-
-                        </Grid.Row>
-
-                        <Grid.Row
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2"
-                            columns={2}
-                        >
-
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.expires} />
-                                <p>Expires</p>
-                            </Grid.Column>
-
-                            <Grid.Column className="p-0">
-                                <CopyTooltip
-                                    value={aliceNetAdapter.getDSExp(
-                                        dataStore['DSLinker']['DSPreImage']['RawData'],
-                                        dataStore['DSLinker']['DSPreImage']['Deposit'],
-                                        dataStore['DSLinker']['DSPreImage']['IssuedAt']
-                                    )}
-                                    content="Copy Value"
-                                >
-                                    <p>{aliceNetAdapter.getDSExp(
-                                        dataStore['DSLinker']['DSPreImage']['RawData'],
-                                        dataStore['DSLinker']['DSPreImage']['Deposit'],
-                                        dataStore['DSLinker']['DSPreImage']['IssuedAt']
-                                    )}</p>
-                                </CopyTooltip>
-                            </Grid.Column>
-
-                        </Grid.Row>
-
-                        <Grid.Row
-                            key={`row-hash-${index}`}
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack rounded-b-md mobile:p-2"
-                            columns={2}
-                        >
-
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.txHash} />
-                                <p>Transaction Hash</p>
-                            </Grid.Column>
-
-                            <Grid.Column className="p-0">
-                                <CopyTooltip value={dataStore['DSLinker']['TxHash']} content="Copy Hash">
-                                    <Link
-                                        className="text-neongreen hover:text-neongreen hover:opacity-80 break-all"
-                                        to={`/tx/${dataStore['DSLinker']['TxHash']}`}
-                                    >
-                                        {`0x${dataStore['DSLinker']['TxHash']}`}
-                                    </Link>
-                                </CopyTooltip>
-                            </Grid.Column>
-
-                        </Grid.Row>
+                                    {`0x${dataStore['DSLinker']['TxHash']}`}
+                                </Link>
+                            </CopyTooltip>
+                        </TwoColumnsRow>
 
                     </Grid>
 
                 </CollapsableCard>
+
             ))}
 
         </div>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -15,6 +15,7 @@ export * from './page';
 export * from './search';
 export * from './searchNotFound';
 export * from './table';
+export * from './twoColumnsRow';
 export * from './txHashList';
 export * from './txViewDataStore';
 export * from './txViewValueStore';

--- a/src/components/twoColumnsRow/TwoColumnsRow.jsx
+++ b/src/components/twoColumnsRow/TwoColumnsRow.jsx
@@ -3,7 +3,7 @@ import { Grid } from "semantic-ui-react"
 import { HelpTooltip } from "components";
 import { classNames } from "utils";
 
-export function TwoColumnsRow({ title, tooltipContent, children, lastRow = false }) {
+export function TwoColumnsRow({ title, tooltipContent, children, width = 3, lastRow = false }) {
 
     return (
 
@@ -16,7 +16,7 @@ export function TwoColumnsRow({ title, tooltipContent, children, lastRow = false
             columns={2}
         >
 
-            <Grid.Column className="flex items-center gap-5 p-0" mobile={1} computer={3}>
+            <Grid.Column className="flex items-center gap-3 p-0" mobile={1} computer={width}>
                 <HelpTooltip content={tooltipContent} />
                 <p>{title}</p>
             </Grid.Column>

--- a/src/components/twoColumnsRow/index.js
+++ b/src/components/twoColumnsRow/index.js
@@ -1,0 +1,1 @@
+export * from "./TwoColumnsRow";

--- a/src/components/txViewDataStore/TxViewDataStore.jsx
+++ b/src/components/txViewDataStore/TxViewDataStore.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Grid } from "semantic-ui-react";
 import { useHistory } from "react-router-dom";
-import { content, CopyTooltip, HelpTooltip } from "components";
+import { content, CopyTooltip, TwoColumnsRow } from "components";
 import { aliceNetAdapter } from "adapter/alicenetadapter";
 
 export function TxViewDataStore({ dataStore }) {
@@ -12,158 +12,85 @@ export function TxViewDataStore({ dataStore }) {
 
         <Grid padded="vertically" className="mx-0 break-words" columns={"equal"} stackable>
 
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
+            <TwoColumnsRow title="Index" tooltipContent={content.index} width={4}>
+                <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['Index']} content="Copy Value">
+                    <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['Index']}`}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.index} />
-                    <p>Index</p>
-                </Grid.Column>
+            <TwoColumnsRow title="Raw Data" tooltipContent={content.rawData} width={4}>
+                <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['RawData']} content="Copy Data">
+                    <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['RawData']}`}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-                <Grid.Column className="p-0">
-                    <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['Index']} content="Copy Value">
-                        <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['Index']}`}</p>
+            <TwoColumnsRow title="Owner" tooltipContent={content.owner} width={4}>
+                <div className="flex items-start gap-3 mobile:flex-col mobile:gap-5">
+                    <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['Owner']} content="Copy Address">
+                        <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['Owner']}`}</p>
                     </CopyTooltip>
-                </Grid.Column>
 
-            </Grid.Row>
+                    <Button
+                        className="text-xs px-3 py-1 ml-2 rounded-sm mobile:w-full mobile:m-0 mobile:text-base"
+                        onClick={() =>
+                            history.push(`/data/${dataStore['DSLinker']['DSPreImage']['Owner'].substr(4)}`)
+                        }
+                        content="View Owner DataStores"
+                    />
+                </div>
+            </TwoColumnsRow>
 
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
+            <TwoColumnsRow title="Issued At" tooltipContent={content.epoch} width={4}>
+                <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['IssuedAt']} content="Copy Value">
+                    <p className="break-all">{dataStore['DSLinker']['DSPreImage']['IssuedAt']}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.rawData} />
-                    <p>Raw Data</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['RawData']} content="Copy Data">
-                        <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['RawData']}`}</p>
-                    </CopyTooltip>
-                </Grid.Column>
-
-            </Grid.Row>
-
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.owner} />
-                    <p>Owner</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <div className="flex items-start gap-3 mobile:flex-col mobile:gap-5">
-                        <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['Owner']} content="Copy Address">
-                            <p className="break-all">{`0x${dataStore['DSLinker']['DSPreImage']['Owner']}`}</p>
-                        </CopyTooltip>
-
-                        <Button
-                            className="text-xs px-3 py-1 ml-2 rounded-sm mobile:w-full mobile:m-0 mobile:text-base"
-                            onClick={() =>
-                                history.push(`/data/${dataStore['DSLinker']['DSPreImage']['Owner'].substr(4)}`)
-                            }
-                            content="View Owner DataStores"
-                        />
-                    </div>
-                </Grid.Column>
-
-            </Grid.Row>
-
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.epoch} />
-                    <p>Issued At</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['IssuedAt']} content="Copy Value">
-                        <p className="break-all">{dataStore['DSLinker']['DSPreImage']['IssuedAt']}</p>
-                    </CopyTooltip>
-                </Grid.Column>
-
-            </Grid.Row>
-
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.expires} />
-                    <p>Expires</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <CopyTooltip
-                        value={
+            <TwoColumnsRow title="Expires" tooltipContent={content.expires} width={4}>
+                <CopyTooltip
+                    value={
+                        aliceNetAdapter.getDSExp(
+                            dataStore['DSLinker']['DSPreImage']['RawData'],
+                            dataStore['DSLinker']['DSPreImage']['Deposit'],
+                            dataStore['DSLinker']['DSPreImage']['IssuedAt']
+                        )
+                    }
+                    content="Copy Value"
+                >
+                    <p className="break-all">
+                        {
                             aliceNetAdapter.getDSExp(
                                 dataStore['DSLinker']['DSPreImage']['RawData'],
                                 dataStore['DSLinker']['DSPreImage']['Deposit'],
                                 dataStore['DSLinker']['DSPreImage']['IssuedAt']
                             )
                         }
-                        content="Copy Value"
-                    >
-                        <p className="break-all">
-                            {
-                                aliceNetAdapter.getDSExp(
-                                    dataStore['DSLinker']['DSPreImage']['RawData'],
-                                    dataStore['DSLinker']['DSPreImage']['Deposit'],
-                                    dataStore['DSLinker']['DSPreImage']['IssuedAt']
-                                )
-                            }
-                        </p>
-                    </CopyTooltip>
-                </Grid.Column>
+                    </p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-            </Grid.Row>
+            <TwoColumnsRow title="Deposit" tooltipContent={content.deposit} width={4}>
+                <CopyTooltip
+                    value={aliceNetAdapter.hexToInt(dataStore['DSLinker']['DSPreImage']['Deposit'])}
+                    content="Copy Value"
+                >
+                    <p className="break-all">{aliceNetAdapter.hexToInt(dataStore['DSLinker']['DSPreImage']['Deposit'])}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
+            <TwoColumnsRow title="Transaction Index" tooltipContent={content.txIndex} width={4}>
+                <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['TXOutIdx']} content="Copy Index">
+                    <p className="break-all">{dataStore['DSLinker']['DSPreImage']['TXOutIdx']}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.deposit} />
-                    <p>Expires</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <CopyTooltip
-                        value={aliceNetAdapter.hexToInt(dataStore['DSLinker']['DSPreImage']['Deposit'])}
-                        content="Copy Value"
-                    >
-                        <p className="break-all">{aliceNetAdapter.hexToInt(dataStore['DSLinker']['DSPreImage']['Deposit'])}</p>
-                    </CopyTooltip>
-                </Grid.Column>
-
-            </Grid.Row>
-
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.txIndex} />
-                    <p>Transaction Index</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0 pr-20">
-                    <CopyTooltip value={dataStore['DSLinker']['DSPreImage']['TXOutIdx']} content="Copy Index">
-                        <p className="break-all">{dataStore['DSLinker']['DSPreImage']['TXOutIdx']}</p>
-                    </CopyTooltip>
-                </Grid.Column>
-
-            </Grid.Row>
-
-            <Grid.Row
-                className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2 rounded-b-md"
-                columns={2}
-            >
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.signature} />
-                    <p>Signature</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0 pr-20">
+            <TwoColumnsRow title="Signature" tooltipContent={content.signature} width={4} lastRow>
+                <div className="p-0 pr-20 mobile:pr-0">
                     <CopyTooltip value={dataStore['Signature']} content="Copy Signature">
                         <p className="break-all">{`0x${dataStore['Signature']}`}</p>
                     </CopyTooltip>
-                </Grid.Column>
-
-            </Grid.Row>
+                </div>
+            </TwoColumnsRow>
 
         </Grid>
     );

--- a/src/components/txViewValueStore/TxViewValueStore.jsx
+++ b/src/components/txViewValueStore/TxViewValueStore.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Grid } from "semantic-ui-react";
 import { useHistory } from "react-router-dom";
-import { content, CopyTooltip, HelpTooltip } from "components";
+import { content, CopyTooltip, TwoColumnsRow } from "components";
 import { aliceNetAdapter } from "adapter/alicenetadapter";
 
 export function TxViewValueStore({ valueStore }) {
@@ -12,63 +12,36 @@ export function TxViewValueStore({ valueStore }) {
 
         <Grid padded="vertically" className="mx-0 break-words" columns={"equal"} stackable>
 
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
+            <TwoColumnsRow title="Value" tooltipContent={content.value} width={4}>
+                <CopyTooltip
+                    value={aliceNetAdapter.hexToInt(valueStore['VSPreImage']['Value'])}
+                    content="Copy Value"
+                >
+                    <p className="break-all">{aliceNetAdapter.hexToInt(valueStore['VSPreImage']['Value'])}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.value} />
-                    <p>Value</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <CopyTooltip
-                        value={aliceNetAdapter.hexToInt(valueStore['VSPreImage']['Value'])}
-                        content="Copy Value"
-                    >
-                        <p className="break-all">{aliceNetAdapter.hexToInt(valueStore['VSPreImage']['Value'])}</p>
+            <TwoColumnsRow title="Owner" tooltipContent={content.owner} width={4}>
+                <div className="flex items-start gap-3 mobile:flex-col mobile:gap-5">
+                    <CopyTooltip value={valueStore['VSPreImage']['Owner']} content="Copy Address">
+                        <p className="break-all">{`0x${valueStore['VSPreImage']['Owner']}`}</p>
                     </CopyTooltip>
-                </Grid.Column>
 
-            </Grid.Row>
+                    <Button
+                        className="text-xs px-3 py-1 ml-2 rounded-sm mobile:w-full mobile:m-0 mobile:text-base"
+                        onClick={() =>
+                            history.push(`/data/${valueStore['VSPreImage']['Owner'].substr(4)}`)
+                        }
+                        content="View Owner DataStores"
+                    />
+                </div>
+            </TwoColumnsRow>
 
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2" columns={2}>
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.owner} />
-                    <p>Owner</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0">
-                    <div className="flex items-start gap-3 mobile:flex-col mobile:gap-5">
-                        <CopyTooltip value={valueStore['VSPreImage']['Owner']} content="Copy Address">
-                            <p className="break-all">{`0x${valueStore['VSPreImage']['Owner']}`}</p>
-                        </CopyTooltip>
-
-                        <Button
-                            className="text-xs px-3 py-1 ml-2 rounded-sm mobile:w-full mobile:m-0 mobile:text-base"
-                            onClick={() =>
-                                history.push(`/data/${valueStore['VSPreImage']['Owner'].substr(4)}`)
-                            }
-                            content="View Owner DataStores"
-                        />
-                    </div>
-                </Grid.Column>
-
-            </Grid.Row>
-
-            <Grid.Row className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2 rounded-b-md" columns={2}>
-
-                <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                    <HelpTooltip content={content.txIndex} />
-                    <p>Transaction Index</p>
-                </Grid.Column>
-
-                <Grid.Column className="p-0 pr-20">
-                    <CopyTooltip value={valueStore['VSPreImage']['TXOutIdx']} content="Copy Index">
-                        <p className="break-all">{valueStore['VSPreImage']['TXOutIdx']}</p>
-                    </CopyTooltip>
-                </Grid.Column>
-
-            </Grid.Row>
+            <TwoColumnsRow title="Transaction Index" tooltipContent={content.txIndex} width={4} lastRow>
+                <CopyTooltip value={valueStore['VSPreImage']['TXOutIdx']} content="Copy Index">
+                    <p className="break-all">{valueStore['VSPreImage']['TXOutIdx']}</p>
+                </CopyTooltip>
+            </TwoColumnsRow>
 
         </Grid>
 

--- a/src/components/txViewVin/TxViewVin.jsx
+++ b/src/components/txViewVin/TxViewVin.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Grid } from "semantic-ui-react";
-import { CollapsableCard, content, CopyTooltip, HelpTooltip } from "components";
+import { CollapsableCard, content, CopyTooltip, TwoColumnsRow } from "components";
 
 export function TxViewVin({ txInfo }) {
 
@@ -14,65 +14,35 @@ export function TxViewVin({ txInfo }) {
 
                     <Grid padded="vertically" className="mx-0 break-words" columns={"equal"} stackable>
 
-                        <Grid.Row
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2"
-                            columns={2}
+                        <TwoColumnsRow title="Consumed Transaction" tooltipContent={content.consumedTx} width={4}>
+                            <CopyTooltip
+                                value={tx['TXInLinker']['TXInPreImage']['ConsumedTxHash']}
+                                content="Copy Hash"
+                            >
+                                <p className="break-all">{`0x${tx['TXInLinker']['TXInPreImage']['ConsumedTxHash']}`}</p>
+                            </CopyTooltip>
+                        </TwoColumnsRow>
+
+                        <TwoColumnsRow
+                            title="Consumed Transaction Index"
+                            tooltipContent={content.consumedTxIndex}
+                            width={4}
                         >
+                            <CopyTooltip
+                                value={tx['TXInLinker']['TXInPreImage']['ConsumedTxIdx']}
+                                content="Copy Value"
+                            >
+                                <p className="break-all">{tx['TXInLinker']['TXInPreImage']['ConsumedTxIdx']}</p>
+                            </CopyTooltip>
+                        </TwoColumnsRow>
 
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.consumedTx} />
-                                <p>Consumed Transaction</p>
-                            </Grid.Column>
-
-                            <Grid.Column className="p-0">
-                                <CopyTooltip
-                                    value={tx['TXInLinker']['TXInPreImage']['ConsumedTxHash']}
-                                    content="Copy Hash"
-                                >
-                                    <p className="break-all">{`0x${tx['TXInLinker']['TXInPreImage']['ConsumedTxHash']}`}</p>
-                                </CopyTooltip>
-                            </Grid.Column>
-
-                        </Grid.Row>
-
-                        <Grid.Row
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack mobile:p-2"
-                            columns={2}
-                        >
-
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.consumedTxIndex} />
-                                <p>Consumed Transaction Index</p>
-                            </Grid.Column>
-
-                            <Grid.Column className="p-0">
-                                <CopyTooltip
-                                    value={tx['TXInLinker']['TXInPreImage']['ConsumedTxIdx']}
-                                    content="Copy Value"
-                                >
-                                    <p className="break-all">{tx['TXInLinker']['TXInPreImage']['ConsumedTxIdx']}</p>
-                                </CopyTooltip>
-                            </Grid.Column>
-
-                        </Grid.Row>
-
-                        <Grid.Row
-                            className="px-6 bg-rowblack border-0 border-t border-tableblack rounded-b-md mobile:p-2"
-                            columns={2}
-                        >
-
-                            <Grid.Column className="flex items-center gap-3 p-0" width={4}>
-                                <HelpTooltip content={content.signature} />
-                                <p>Signature</p>
-                            </Grid.Column>
-
-                            <Grid.Column className="p-0 pr-20">
+                        <TwoColumnsRow title="Signature" tooltipContent={content.signature} width={4} lastRow>
+                            <div className="p-0 pr-20 mobile:pr-0">
                                 <CopyTooltip value={tx['Signature']} content="Copy Hash">
                                     <p className="break-all">{`0x${tx['Signature']}`}</p>
                                 </CopyTooltip>
-                            </Grid.Column>
-
-                        </Grid.Row>
+                            </div>
+                        </TwoColumnsRow>
 
                     </Grid>
 


### PR DESCRIPTION
We are using this schema everywhere. A row with two columns. The first one holds a title and a tooltip. The second one any kind of content. This is a proposal for a refactory that needs to be applied on some other components as well. It can be extended two: number of columns, classnames, etc.